### PR TITLE
fix: color-control in react 17 and setValue to hex

### DIFF
--- a/src/components/controls/color-control.tsx
+++ b/src/components/controls/color-control.tsx
@@ -50,7 +50,11 @@ export function ColorControl({
   const [open, setOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>();
   const handleClick = (e: any) => {
-    if (pickerRef.current && !pickerRef.current.contains(e.target)) {
+    if (
+      e.target.id !== 'color-picker'
+      && pickerRef.current
+      && !pickerRef.current.contains(e.target)
+    ) {
       setOpen(false);
     }
   };
@@ -64,7 +68,7 @@ export function ColorControl({
 
   const pickerProps: any = {
     color: value,
-    onChange: (color: any) => setValue(color.rgb),
+    onChange: (color: any) => setValue(color.hex),
     disableAlpha: options.disableAlpha,
     colors: options.colors,
   };
@@ -120,6 +124,7 @@ export function ColorControl({
         ) : (
           <>
             <ColorBox
+              id="color-picker"
               style={{ backgroundColor: value }}
               onClick={() => setOpen(lastValue => !lastValue)}
             />


### PR DESCRIPTION
#29 This pull request is fixing two bugs:

- handleClick was always closing the colorbox, so, I added to then an id and prevent setOpen dont get called when clicked in it. This behavior was only occured in react ˆ17.
- onChange color was setting value with rbg object instead of hex, which is the standard of color-control.